### PR TITLE
Fix/firefox svg image

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@denodeland/qr-code-styling",
-  "version": "1.6.1-beta.1",
+  "version": "1.6.1",
   "description": "Add a style and an image to your QR code",
   "main": "lib/qr-code-styling.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@denodeland/qr-code-styling",
-  "version": "1.6.0",
+  "version": "1.6.1-beta.1",
   "description": "Add a style and an image to your QR code",
   "main": "lib/qr-code-styling.js",
   "types": "lib/index.d.ts",

--- a/src/core/QRCodeStyling.ts
+++ b/src/core/QRCodeStyling.ts
@@ -146,10 +146,20 @@ export default class QRCodeStyling {
       const img = new Image();
       img.crossOrigin = "anonymous";
       img.onload = function () {
+        let resizeHeight = Math.round(height || img.height / (img.width / width));
+
+        // firefox patch, svg images have no height unless they are in the DOM
+        if (!resizeHeight) {
+          img.style.visibility = "hidden";
+          document.body.appendChild(img);
+          resizeHeight = Math.round(img.height / (img.width / width));
+          img.remove();
+        }
+
         const imgUnknown = img as unknown;
         createImageBitmap(imgUnknown as ImageBitmapSource, {
-          resizeWidth: width,
-          resizeHeight: height || img.height / (img.width / width),
+          resizeWidth: Math.round(width),
+          resizeHeight,
           resizeQuality: "high"
         })
           .then(resolve)


### PR DESCRIPTION
Workaround para el bug de firefox en imagenes svg

Referencia: https://bugzilla.mozilla.org/show_bug.cgi?id=700533